### PR TITLE
Update locker.py

### DIFF
--- a/pyrfuniverse/utils/locker.py
+++ b/pyrfuniverse/utils/locker.py
@@ -34,10 +34,13 @@ class Locker:
         self.fp = None
 
     def __enter__(self):
-        self.fp = open(self.lck_path)
+        self.fp = open(self.lck_path, 'r+')  # Open the file in read-write mode
         lock(self.fp)
+        return self.fp
 
     def __exit__(self, _type, value, tb):
+        try:
+            unlock(self.fp)
+        finally:
+            self.fp.close()
         time.sleep(0.1)
-        unlock(self.fp)
-        self.fp.close()


### PR DESCRIPTION
There was an issue with the installation using `pip install -e .`. The error is `...fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
      OSError: [Errno 9] Bad file descriptor
      [end of output]`
Fixed this issue in this PR by changing `self.fp = open(self.lck_path)` to `self.fp = open(self.lck_path, 'r+')` to open the file in read-write mode.